### PR TITLE
TUNアダプターの構築におけるopenvpnエラーについて

### DIFF
--- a/nm-vpngate
+++ b/nm-vpngate
@@ -677,7 +677,11 @@ _connect_vpn_nm(){
 _connect_vpn_openvpn(){
     local _ovpn_file="$CONFIG_DIR/$PROFILE_NAME.ovpn"
     test -e "$_ovpn_file" || { _error "$PROFILE_NAME was not found."; return 1; }
-    _run sudo openvpn --config "$_ovpn_file"
+    if [[ "${MODE}" = "GUI-"* ]]; then
+        _run pkexec openvpn --config "$_ovpn_file"
+    else
+        _run sudo openvpn --config "$_ovpn_file"
+    fi
 }
 
 _connect_vpn(){

--- a/nm-vpngate
+++ b/nm-vpngate
@@ -677,7 +677,7 @@ _connect_vpn_nm(){
 _connect_vpn_openvpn(){
     local _ovpn_file="$CONFIG_DIR/$PROFILE_NAME.ovpn"
     test -e "$_ovpn_file" || { _error "$PROFILE_NAME was not found."; return 1; }
-    _run openvpn --config "$_ovpn_file"
+    _run sudo openvpn --config "$_ovpn_file"
 }
 
 _connect_vpn(){


### PR DESCRIPTION
openvpnが正しくTUNアダプターを構築するにはrootユーザが必要と言う問題です。

UID0でないユーザで`nm-vpngate`を実行した場合、正しく作動しないことがあります。
もちろん`sudo nm-vpngate`で実行した場合は問題ないけれど、GUIアプリをUID0のまま実行するのはあまりお勧めできません。
一時対策として`nm-vpngate`スクリプト内に`sudo openvpn`に変えましたが、Hayao0819の自由ですがGUIが第一なら、`pkexec`とかを使う方がいいかもしれません。

試したのは、`--gui ZENITY`とデフォルトCLIのみ、両方sudoなしでは接続に失敗。
こっちが何か見過ごしているのなら、先に誤ります。